### PR TITLE
Some reusability changes!

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 ﻿using StereoKit;
+using System;
 
 namespace VideoKit;
 
@@ -11,28 +12,47 @@ class Program
         if (!SK.Initialize(settings))
             return;
 
-        using var videoPlayer = new VideoKitPlayer();
-        var texture = videoPlayer.InitializeSoundAndTexture();
+        using VideoKitPlayer videoPlayer = new();
+        videoPlayer.PlayVideoAsync(new Uri("https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4"));
 
-        videoPlayer.PlayVideoAsync("");
+        Material videoMaterial = Material.Unlit.Copy();
+        videoMaterial[MatParamName.DiffuseTex] = videoPlayer.InitializeSoundAndTexture();
 
         // Create assets used by the app
         Pose cubePose = new Pose(0, 0, -1.5f);
-        Model cube = Model.FromMesh(Mesh.GenerateRoundedCube(new Vec3(16, 9, 1) / 10, 0.02f), Material.UI);
+        Model cube = Model.FromMesh(Mesh.GenerateRoundedCube(new Vec3(16, 9, 1) / 10, 0.02f), videoMaterial);
 
         Renderer.SkyTex = Tex.FromCubemap("sky/space.ktx2");
 
-        Material videoMaterial = Material.Unlit;
-        videoMaterial[MatParamName.DiffuseTex] = texture;
-
+        Pose uiPose = UI.PopupPose();
+        float timestampDisplay = 0;
         // Core application loop
         SK.Run(() =>
         {
             videoPlayer.Step();
-            UI.Handle("Cube", ref cubePose, cube.Bounds);
 
-            // videoPlayer.ActiveSoundStream.Play(cubePose.position);
-            cube.Draw(videoMaterial, cubePose.ToMatrix(), Color.White);
+            UI.Handle("Cube", ref cubePose, cube.Bounds);
+            videoPlayer.SoundPosition = cubePose.position;
+            cube.Draw(cubePose.ToMatrix());
+
+            UI.WindowBegin("VideoKitPlayer", ref uiPose, Vec2.UnitX * 0.3f);
+
+            if (UI.Button("Play"))      videoPlayer.Play();
+            if (UI.Button("Pause"))     videoPlayer.Pause();
+            if (UI.Button("Skip -15s")) videoPlayer.Time -= 15_000;
+            if (UI.Button("Skip +15s")) videoPlayer.Time += 15_000;
+
+            if (UI.HSlider("timer", ref timestampDisplay, 0, videoPlayer.Length, step: 0, notifyOn: UINotify.Finalize))
+                videoPlayer.Time = (long)timestampDisplay;
+            // Don't update the seek time if the user is interacting with it.
+            if (!UI.LastElementActive.IsActive())
+                timestampDisplay = videoPlayer.Time;
+
+            TimeSpan elapsed = TimeSpan.FromMilliseconds(videoPlayer.Time);
+            TimeSpan total   = TimeSpan.FromMilliseconds(videoPlayer.Length);
+            UI.Text( $"Time: {elapsed.ToString(@"hh\:mm\:ss")}/{total.ToString(@"hh\:mm\:ss")}" );
+
+            UI.WindowEnd();
         });
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -12,15 +12,11 @@ class Program
         if (!SK.Initialize(settings))
             return;
 
+        // Create assets used by the app
+
         using VideoKitPlayer videoPlayer = new();
         videoPlayer.PlayVideoAsync(new Uri("https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4"));
-
-        Material videoMaterial = Material.Unlit.Copy();
-        videoMaterial[MatParamName.DiffuseTex] = videoPlayer.InitializeSoundAndTexture();
-
-        // Create assets used by the app
-        Pose cubePose = new Pose(0, 0, -1.5f);
-        Model cube = Model.FromMesh(Mesh.GenerateRoundedCube(new Vec3(16, 9, 1) / 10, 0.02f), videoMaterial);
+        Sprite videoSprite = Sprite.FromTex( videoPlayer.InitializeSoundAndTexture(), SpriteType.Single );
 
         Renderer.SkyTex = Tex.FromCubemap("sky/space.ktx2");
 
@@ -30,16 +26,18 @@ class Program
         SK.Run(() =>
         {
             videoPlayer.Step();
+            videoPlayer.SoundPosition = uiPose.position;
 
-            UI.Handle("Cube", ref cubePose, cube.Bounds);
-            videoPlayer.SoundPosition = cubePose.position;
-            cube.Draw(cubePose.ToMatrix());
+            UI.WindowBegin("VideoKitPlayer", ref uiPose, new Vec2(0.4f,0));
 
-            UI.WindowBegin("VideoKitPlayer", ref uiPose, Vec2.UnitX * 0.3f);
+            UI.Image(videoSprite, new Vec2(UI.LayoutRemaining.x,0));
 
             if (UI.Button("Play"))      videoPlayer.Play();
+            UI.SameLine();
             if (UI.Button("Pause"))     videoPlayer.Pause();
+            UI.SameLine();
             if (UI.Button("Skip -15s")) videoPlayer.Time -= 15_000;
+            UI.SameLine();
             if (UI.Button("Skip +15s")) videoPlayer.Time += 15_000;
 
             if (UI.HSlider("timer", ref timestampDisplay, 0, videoPlayer.Length, step: 0, notifyOn: UINotify.Finalize))

--- a/VideoKitPlayer.cs
+++ b/VideoKitPlayer.cs
@@ -76,6 +76,7 @@ public class VideoKitPlayer : IDisposable
         {
             Anisoptropy = 4,
             Id = "VideoTextureCool",
+            AddressMode = TexAddress.Clamp,
         };
         _videoTextureData = new byte[Pitch * Lines];
         VideoTexture.SetSize((int)Pitch, (int)Lines);


### PR DESCRIPTION
Some of this is maybe opinionated, so feel free to disregard! I just wanted to make the `VideoKitPlayer` class a bit more re-usable in a wider variety of cases, and that means pulling out the UI into a separate place! There's definitely more that I'd _love_ to do to make this robust, (like I'm not thrilled with how it behaves when the video gets to the end) but I think this PR has some nice changes either way :)

- Move player UI out of the VideoKitPlayer class for re-usability. This means adding some public properties/methods.
- Make video texture a `Sprite` and display it on the UI instead of a free-floating Mesh.
- Different method of doing time seek based on `UI.LastElementActive`.
- Position information hooked up to the video's audio stream instance.
- Video Tex uses AddressMode.Clamp by default now. This prevents wrapped border artifacts on uses like `Sprite`s.

Tested on Win11 and Quest 3

![image](https://github.com/user-attachments/assets/3978ae3e-7a95-4b7d-be7b-42cfe07d2e6d)
